### PR TITLE
do not validate the lastSeen property as being in the past

### DIFF
--- a/src/main/java/org/graylog/plugins/collector/collectors/Collector.java
+++ b/src/main/java/org/graylog/plugins/collector/collectors/Collector.java
@@ -22,7 +22,6 @@ import org.joda.time.DateTime;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Past;
 import javax.validation.constraints.Size;
 
 public interface Collector {
@@ -38,7 +37,6 @@ public interface Collector {
     String getCollectorVersion();
 
     @NotNull
-    @Past
     DateTime getLastSeen();
 
     @NotNull


### PR DESCRIPTION
this breaks due to a race condition creating the timestamp and validating the field. if both happens within the same millisecond it's not "past"

fix Graylog2/graylog2-server#2002
fix Graylog2/graylog2-web-interface#1726