### PR TITLE
Improvements in server side validations

### DIFF
--- a/src/main/java/org/graylog/plugins/collector/configurations/CollectorConfigurationService.java
+++ b/src/main/java/org/graylog/plugins/collector/configurations/CollectorConfigurationService.java
@@ -234,12 +234,15 @@ public class CollectorConfigurationService {
         final String outputId = request.forwardTo();
         this.findOutput(collectorConfiguration, outputId).orElseThrow(() -> new NotFoundException("Could not find output " + outputId));
 
+        final CollectorInput toSave = CollectorInput.create(inputId, request.backend(), request.type(), request.name(), request.forwardTo(), request.properties());
+
+
         ListIterator<CollectorInput> inputIterator = collectorConfiguration.inputs().listIterator();
         while (inputIterator.hasNext()) {
             int i = inputIterator.nextIndex();
             CollectorInput input = inputIterator.next();
             if (input.inputId().equals(inputId)) {
-                collectorConfiguration.inputs().set(i, request);
+                collectorConfiguration.inputs().set(i, toSave);
             }
         }
         return collectorConfiguration;
@@ -247,13 +250,14 @@ public class CollectorConfigurationService {
 
     public CollectorConfiguration updateOutputFromRequest(String id, String outputId, CollectorOutput request) {
         CollectorConfiguration collectorConfiguration = dbCollection.findOne(DBQuery.is("_id", id));
+        final CollectorOutput toSave = CollectorOutput.create(outputId, request.backend(), request.type(), request.name(), request.properties());
 
         ListIterator<CollectorOutput> outputIterator = collectorConfiguration.outputs().listIterator();
         while (outputIterator.hasNext()) {
             int i = outputIterator.nextIndex();
             CollectorOutput output = outputIterator.next();
             if (output.outputId().equals(outputId)) {
-                collectorConfiguration.outputs().set(i, request);
+                collectorConfiguration.outputs().set(i, toSave);
             }
         }
         return collectorConfiguration;
@@ -261,13 +265,14 @@ public class CollectorConfigurationService {
 
     public CollectorConfiguration updateSnippetFromRequest(String id, String snippetId, CollectorConfigurationSnippet request) {
         CollectorConfiguration collectorConfiguration = dbCollection.findOne(DBQuery.is("_id", id));
+        final CollectorConfigurationSnippet toSave = CollectorConfigurationSnippet.create(snippetId, request.backend(), request.name(), request.snippet());
 
         ListIterator<CollectorConfigurationSnippet> snippetIterator = collectorConfiguration.snippets().listIterator();
         while (snippetIterator.hasNext()) {
             int i = snippetIterator.nextIndex();
             CollectorConfigurationSnippet snippet = snippetIterator.next();
             if (snippet.snippetId().equals(snippetId)) {
-                collectorConfiguration.snippets().set(i, request);
+                collectorConfiguration.snippets().set(i, toSave);
             }
         }
         return collectorConfiguration;

--- a/src/main/java/org/graylog/plugins/collector/configurations/rest/resources/CollectorConfigurationResource.java
+++ b/src/main/java/org/graylog/plugins/collector/configurations/rest/resources/CollectorConfigurationResource.java
@@ -182,13 +182,14 @@ public class CollectorConfigurationResource extends RestResource implements Plug
     @ApiOperation(value = "Update a configuration input",
             notes = "This is a stateless method which updates a collector input")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "The supplied request is not valid.")
+            @ApiResponse(code = 400, message = "The supplied request is not valid."),
+            @ApiResponse(code = 404, message = "Output assigned in forward_to does not exist.")
     })
     public Response updateInput(@ApiParam(name = "id", required = true)
                                 @PathParam("id") @NotEmpty String id,
                                 @ApiParam(name = "input_id", required = true)
                                 @PathParam("input_id") @NotEmpty String inputId,
-                                @ApiParam(name = "JSON body", required = true) @Valid @NotNull CollectorInput request) {
+                                @ApiParam(name = "JSON body", required = true) @Valid @NotNull CollectorInput request) throws NotFoundException {
         final CollectorConfiguration collectorConfiguration = collectorConfigurationService.updateInputFromRequest(id, inputId, request);
         collectorConfigurationService.save(collectorConfiguration);
 
@@ -283,12 +284,13 @@ public class CollectorConfigurationResource extends RestResource implements Plug
     @ApiOperation(value = "Create a configuration input",
             notes = "This is a stateless method which inserts a collector input")
     @ApiResponses(value = {
-            @ApiResponse(code = 400, message = "The supplied request is not valid.")
+            @ApiResponse(code = 400, message = "The supplied request is not valid."),
+            @ApiResponse(code = 404, message = "Specified output in forward_to does not exist.")
     })
     public Response createInput(@ApiParam(name = "id", required = true)
                                 @PathParam("id") @NotEmpty String id,
                                 @ApiParam(name = "JSON body", required = true)
-                                @Valid @NotNull CollectorInput request) {
+                                @Valid @NotNull CollectorInput request) throws NotFoundException {
         final CollectorConfiguration collectorConfiguration = collectorConfigurationService.withInputFromRequest(id, request);
         collectorConfigurationService.save(collectorConfiguration);
 

--- a/src/web/collector-configuration/CollectorConfiguration.jsx
+++ b/src/web/collector-configuration/CollectorConfiguration.jsx
@@ -64,11 +64,12 @@ const CollectorConfiguration = React.createClass({
   },
 
   _inputFormatter(input) {
+    const output = this._getOutputById(input.forward_to);
     return (
       <tr key={input.input_id}>
         <td>{input.name}</td>
         <td>{input.type}</td>
-        <td>{this._getOutputById(input.forward_to).name}</td>
+        <td>{output ? output.name : <em>Unknown output</em>}</td>
         <td>{input.input_id}</td>
         <td>
           <DeleteConfirmButton entity={input} type="input" onClick={this._deleteInput} />


### PR DESCRIPTION
This PR takes care of the following:

- Validate outputs IDs when they are assigned to inputs, ensuring that the outputs exist at the time
- Ensure the user cannot modify inputs, outputs, or snippets IDs once they are created, ignoring the IDs that may be passed in the JSON body
- In the UI, do not attempt to get the output name if the output is not available, fixing https://github.com/Graylog2/graylog2-server/issues/2247

The changes should also go into the master branch.