### PR TITLE
Adapting to 2.2 plugin structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   "dependencies": {
   },
   "devDependencies": {
-    "graylog-web-plugin": "^2.2.0-SNAPSHOT"
+    "graylog-web-plugin": "file:../graylog2-server/graylog2-web-interface/packages/graylog-web-plugin"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "url": "Graylog2/graylog-plugin-collector"
   },
   "scripts": {
-    "start": "./node_modules/.bin/webpack-dev-server",
-    "build": "./node_modules/.bin/webpack"
+    "build": "webpack --bail -p"
   },
   "keywords": [
     "graylog"
@@ -16,33 +15,8 @@
   "author": "Graylog, Inc. <hello@graylog.com>",
   "license": "GPL-3.0",
   "dependencies": {
-    "history": "^1.17.0",
-    "javascript-natural-sort": "^0.7.1",
-    "react": "0.14.x",
-    "react-bootstrap": "^0.28.1",
-    "react-dom": "^0.14.5",
-    "react-router": "~1.0.0",
-    "react-router-bootstrap": "^0.19.0",
-    "reflux": "^0.2.12"
   },
   "devDependencies": {
-    "babel-core": "^5.8.25",
-    "babel-eslint": "^4.1.6",
-    "babel-loader": "^5.3.2",
-    "css-loader": "^0.23.1",
-    "eslint": "^2.10.2",
-    "eslint-config-graylog": "^1.0.0",
-    "eslint-loader": "^1.0.0",
-    "estraverse-fb": "^1.3.1",
-    "file-loader": "^0.9.0",
-    "graylog-web-plugin": "latest",
-    "graylog-web-manifests": "2.0.0-alpha.3",
-    "json-loader": "^0.5.4",
-    "less": "^2.5.3",
-    "less-loader": "^2.2.1",
-    "react-hot-loader": "^1.3.0",
-    "style-loader": "^0.13.0",
-    "url-loader": "^0.5.6",
-    "webpack": "^1.12.2"
+    "graylog-web-plugin": "^2.2.0-SNAPSHOT"
   }
 }


### PR DESCRIPTION
This is a sample change to show how plugins would need to be adapted to profit from the simplified dependency and build config management using the `graylog-web-plugin` module. Most explicit dependencies are removed and instead used transitively from the `graylog-web-plugin` module. It is referenced from a `graylog2-server` checkout which is located one level higher, just as in `graylog-project` builds. 