### PR TITLE
extract etag cache into its own service

### DIFF
--- a/src/main/java/org/graylog/plugins/collector/CollectorModule.java
+++ b/src/main/java/org/graylog/plugins/collector/CollectorModule.java
@@ -17,12 +17,14 @@
 package org.graylog.plugins.collector;
 
 import com.google.common.base.Supplier;
+import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import org.graylog.plugins.collector.audit.CollectorAuditEventTypes;
 import org.graylog.plugins.collector.collectors.CollectorService;
 import org.graylog.plugins.collector.collectors.CollectorServiceImpl;
 import org.graylog.plugins.collector.collectors.rest.CollectorResource;
 import org.graylog.plugins.collector.configurations.CollectorConfigurationService;
+import org.graylog.plugins.collector.configurations.rest.ConfigurationEtagService;
 import org.graylog.plugins.collector.configurations.rest.resources.CollectorConfigurationResource;
 import org.graylog.plugins.collector.periodical.PurgeExpiredCollectorsThread;
 import org.graylog.plugins.collector.permissions.CollectorRestPermissions;
@@ -43,5 +45,7 @@ public class CollectorModule extends PluginModule {
         addPermissions(CollectorRestPermissions.class);
 
         addAuditEventTypes(CollectorAuditEventTypes.class);
+
+        serviceBinder().addBinding().to(ConfigurationEtagService.class).in(Scopes.SINGLETON);
     }
 }

--- a/src/main/java/org/graylog/plugins/collector/configurations/rest/CollectorConfigurationEtagInvalidation.java
+++ b/src/main/java/org/graylog/plugins/collector/configurations/rest/CollectorConfigurationEtagInvalidation.java
@@ -1,0 +1,18 @@
+package org.graylog.plugins.collector.configurations.rest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class CollectorConfigurationEtagInvalidation {
+
+    @JsonProperty("etag")
+    public abstract String etag();
+
+    @JsonCreator
+    public static CollectorConfigurationEtagInvalidation etag(@JsonProperty("etag") String etag) {
+        return new AutoValue_CollectorConfigurationEtagInvalidation(etag);
+    }
+
+}

--- a/src/main/java/org/graylog/plugins/collector/configurations/rest/ConfigurationEtagService.java
+++ b/src/main/java/org/graylog/plugins/collector/configurations/rest/ConfigurationEtagService.java
@@ -1,0 +1,79 @@
+package org.graylog.plugins.collector.configurations.rest;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.util.concurrent.AbstractIdleService;
+import org.graylog.plugins.collector.configurations.CollectorConfigurationService;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.metrics.CacheStatsSet;
+import org.graylog2.shared.metrics.MetricUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class ConfigurationEtagService extends AbstractIdleService {
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationEtagService.class);
+
+    private final Cache<String, String> cache;
+    private MetricRegistry metricRegistry;
+    private EventBus eventBus;
+    private ClusterEventBus clusterEventBus;
+
+    @Inject
+    public ConfigurationEtagService(MetricRegistry metricRegistry, EventBus eventBus, ClusterEventBus clusterEventBus) {
+        this.metricRegistry = metricRegistry;
+        this.eventBus = eventBus;
+        this.clusterEventBus = clusterEventBus;
+        cache = CacheBuilder.newBuilder()
+                .recordStats()
+                .expireAfterWrite(1, TimeUnit.HOURS)  // TODO magic number
+                .build();
+    }
+
+    @Subscribe
+    public void handleEtagInvalidation(CollectorConfigurationEtagInvalidation event) {
+        if (event.etag().equals("")) {
+            LOG.trace("Invalidating all collector configuration etags");
+            cache.invalidateAll();
+        } else {
+            LOG.trace("Invalidating collector configuration etag {}", event.etag());
+            cache.invalidate(event.etag());
+        }
+    }
+
+    public boolean isPresent(String etag) {
+        return cache.getIfPresent(etag) != null;
+    }
+
+    public void put(String etag) {
+        cache.put(etag, etag);
+    }
+
+    public void invalidate(String etag) {
+        clusterEventBus.post(CollectorConfigurationEtagInvalidation.etag(etag));
+    }
+
+    public void invalidateAll() {
+        cache.invalidateAll();
+        clusterEventBus.post(CollectorConfigurationEtagInvalidation.etag(""));
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        eventBus.register(this);
+        MetricUtils.safelyRegisterAll(metricRegistry, new CacheStatsSet(name(CollectorConfigurationService.class, "etag-cache"), cache));
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        eventBus.unregister(this);
+        metricRegistry.removeMatching((name, metric) -> name.startsWith(name(CollectorConfigurationService.class, "etag-cache")));
+    }
+}

--- a/src/main/java/org/graylog/plugins/collector/configurations/rest/ConfigurationEtagService.java
+++ b/src/main/java/org/graylog/plugins/collector/configurations/rest/ConfigurationEtagService.java
@@ -14,10 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
+@Singleton
 public class ConfigurationEtagService extends AbstractIdleService {
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationEtagService.class);
 


### PR DESCRIPTION
* propagate etag invalidations across all servers in the cluster (as cluster events)
* always invalidates all etags, even though we could probably be smarter about which ones to reload

fixes #37 