### PR TITLE
Add etag cache configuration

### DIFF
--- a/src/main/java/org/graylog/plugins/collector/CollectorModule.java
+++ b/src/main/java/org/graylog/plugins/collector/CollectorModule.java
@@ -17,12 +17,14 @@
 package org.graylog.plugins.collector;
 
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import org.graylog.plugins.collector.audit.CollectorAuditEventTypes;
 import org.graylog.plugins.collector.collectors.CollectorService;
 import org.graylog.plugins.collector.collectors.CollectorServiceImpl;
 import org.graylog.plugins.collector.collectors.rest.CollectorResource;
+import org.graylog.plugins.collector.common.CollectorPluginConfiguration;
 import org.graylog.plugins.collector.configurations.CollectorConfigurationService;
 import org.graylog.plugins.collector.configurations.rest.ConfigurationEtagService;
 import org.graylog.plugins.collector.configurations.rest.resources.CollectorConfigurationResource;
@@ -30,9 +32,19 @@ import org.graylog.plugins.collector.periodical.PurgeExpiredCollectorsThread;
 import org.graylog.plugins.collector.permissions.CollectorRestPermissions;
 import org.graylog.plugins.collector.system.CollectorSystemConfiguration;
 import org.graylog.plugins.collector.system.CollectorSystemConfigurationSupplier;
+import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.plugin.PluginModule;
 
+import java.util.Set;
+
 public class CollectorModule extends PluginModule {
+    @Override
+    public Set<? extends PluginConfigBean> getConfigBeans() {
+        return ImmutableSet.of(
+                new CollectorPluginConfiguration()
+        );
+    }
+
     @Override
     protected void configure() {
         bind(CollectorService.class).to(CollectorServiceImpl.class);

--- a/src/main/java/org/graylog/plugins/collector/common/CollectorPluginConfiguration.java
+++ b/src/main/java/org/graylog/plugins/collector/common/CollectorPluginConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.collector.common;
+
+import com.github.joschi.jadconfig.Parameter;
+import com.github.joschi.jadconfig.util.Duration;
+import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
+import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
+import org.graylog2.plugin.PluginConfigBean;
+
+public class CollectorPluginConfiguration implements PluginConfigBean {
+    private static final String PREFIX = "collector_sidecar_";
+
+    @Parameter(value = PREFIX + "cache_time", validator = PositiveDurationValidator.class)
+    private Duration cacheTime = Duration.hours(1L);
+
+    public Duration getCacheTime() {
+        return cacheTime;
+    }
+
+    @Parameter(value = PREFIX + "cache_max_size", validator = PositiveIntegerValidator.class)
+    private int cacheMaxSize = 100;
+
+    public int getCacheMaxSize() {
+        return cacheMaxSize;
+    }
+}


### PR DESCRIPTION
In case problems pop-up with the default cache settings users can change those with:

  * collector_sidecar_cache_time = 2h
  * collector_sidecar_cache_max_size = 500

Since the Guava Cache is not updatable on the fly we can only provide settings from the configuration file.