### PR TITLE
Update to react-bootstrap 0.30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ build/
 node/
 node_modules/
 target/
+cache/
 dependency-reduced-pom.xml

--- a/src/web/collector-configuration/CollapsibleVerbatim.jsx
+++ b/src/web/collector-configuration/CollapsibleVerbatim.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Alert, Collapse, Input } from 'react-bootstrap';
+import { Alert, Collapse } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
 
 const CollapsibleVerbatim = React.createClass({
   propTypes: {

--- a/src/web/collector-configuration/CollectorConfiguration.jsx
+++ b/src/web/collector-configuration/CollectorConfiguration.jsx
@@ -313,7 +313,8 @@ const CollectorConfiguration = React.createClass({
 
         <Row className="content">
           <Col md={12}>
-            <Tabs activeKey={this.state.tab}
+            <Tabs id="collectorBackendSelector"
+                  activeKey={this.state.tab}
                   animation={false}
                   onSelect={this._tabSwitched}>
               <Tab eventKey="beat" title="Beats"/>

--- a/src/web/collector-configuration/CollectorConfiguration.jsx
+++ b/src/web/collector-configuration/CollectorConfiguration.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Button, Input, Col, Row, Tabs, Tab } from 'react-bootstrap';
+import { Button, Col, Row, Tabs, Tab } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 
+import { Input } from 'components/bootstrap';
 import { DataTable } from 'components/common';
 
 import CopyOutputModal from './CopyOutputModal';

--- a/src/web/collector-configuration/CopyInputModal.jsx
+++ b/src/web/collector-configuration/CopyInputModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 const CopyInputModal = React.createClass({
     propTypes: {

--- a/src/web/collector-configuration/CopyOutputModal.jsx
+++ b/src/web/collector-configuration/CopyOutputModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 const CopyOutputModal = React.createClass({
     propTypes: {

--- a/src/web/collector-configuration/CopySnippetModal.jsx
+++ b/src/web/collector-configuration/CopySnippetModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 const CopySnippetModal = React.createClass({
     propTypes: {

--- a/src/web/collector-configuration/EditInputFields.jsx
+++ b/src/web/collector-configuration/EditInputFields.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 import { KeyValueTable, Select } from 'components/common';

--- a/src/web/collector-configuration/EditInputModal.jsx
+++ b/src/web/collector-configuration/EditInputModal.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { Select } from 'components/common';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 import EditInputFields from './EditInputFields';
 

--- a/src/web/collector-configuration/EditOutputFields.jsx
+++ b/src/web/collector-configuration/EditOutputFields.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Input } from 'react-bootstrap';
+import { Input } from 'components/bootstrap';
 
 import FormUtils from 'util/FormsUtils';
 import { KeyValueTable } from 'components/common';

--- a/src/web/collector-configuration/EditOutputModal.jsx
+++ b/src/web/collector-configuration/EditOutputModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
 import EditOutputFields from './EditOutputFields';

--- a/src/web/collector-configuration/EditSnippetModal.jsx
+++ b/src/web/collector-configuration/EditSnippetModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
 const EditSnippetModal = React.createClass({

--- a/src/web/configurations/CopyConfigurationModal.jsx
+++ b/src/web/configurations/CopyConfigurationModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 const CopyConfigurationModal = React.createClass({
   propTypes: {

--- a/src/web/configurations/EditConfigurationModal.jsx
+++ b/src/web/configurations/EditConfigurationModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 
 const EditConfigurationModal = React.createClass({

--- a/src/web/system-configuration/CollectorSystemConfiguration.jsx
+++ b/src/web/system-configuration/CollectorSystemConfiguration.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Button, Input } from 'react-bootstrap';
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { Button } from 'react-bootstrap';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, ISODurationInput } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 import ISODurationUtils from 'util/ISODurationUtils';


### PR DESCRIPTION
In this case we need to:

- Add ID to the `Tabs` component used in the configuration
- Use the Input adaptor to avoid problems with the new inputs API

Needs to be built against https://github.com/Graylog2/graylog2-server/pull/3598