### PR TITLE
Fix usage of Period instances

### DIFF
--- a/src/main/java/org/graylog/plugins/collector/collectors/CollectorServiceImpl.java
+++ b/src/main/java/org/graylog/plugins/collector/collectors/CollectorServiceImpl.java
@@ -102,7 +102,7 @@ public class CollectorServiceImpl implements CollectorService {
     @Override
     public int destroyExpired(Period period) {
         int count = 0;
-        final DateTime threshold = DateTime.now(DateTimeZone.UTC).minusSeconds(period.getSeconds());
+        final DateTime threshold = DateTime.now(DateTimeZone.UTC).minus(period);
         for (Collector collector : all())
             if (collector.getLastSeen().isBefore(threshold))
                 count += destroy(collector);

--- a/src/main/java/org/graylog/plugins/collector/collectors/rest/CollectorResource.java
+++ b/src/main/java/org/graylog/plugins/collector/collectors/rest/CollectorResource.java
@@ -153,7 +153,7 @@ public class CollectorResource extends RestResource implements PluginRestResourc
         final CollectorSystemConfiguration collectorSystemConfiguration = configSupplier.get();
         CollectorRegistrationResponse collectorRegistrationResponse = CollectorRegistrationResponse.create(
                 CollectorRegistrationConfiguration.create(
-                    collectorSystemConfiguration.collectorUpdateInterval().getSeconds(),
+                    collectorSystemConfiguration.collectorUpdateInterval().toStandardDuration().getStandardSeconds(),
                     collectorSystemConfiguration.collectorSendStatus()),
                 collectorSystemConfiguration.collectorConfigurationOverride(),
                 collectorAction);

--- a/src/main/java/org/graylog/plugins/collector/collectors/rest/models/responses/CollectorRegistrationConfiguration.java
+++ b/src/main/java/org/graylog/plugins/collector/collectors/rest/models/responses/CollectorRegistrationConfiguration.java
@@ -25,13 +25,13 @@ import com.google.auto.value.AutoValue;
 @JsonAutoDetect
 public abstract class CollectorRegistrationConfiguration {
     @JsonProperty
-    public abstract int updateInterval();
+    public abstract long updateInterval();
 
     @JsonProperty
     public abstract boolean sendStatus();
 
     @JsonCreator
-    public static CollectorRegistrationConfiguration create(@JsonProperty("update_interval") int updateInterval,
+    public static CollectorRegistrationConfiguration create(@JsonProperty("update_interval") long updateInterval,
                                                             @JsonProperty("send_status") boolean sendStatus) {
         return new AutoValue_CollectorRegistrationConfiguration(updateInterval, sendStatus);
     }


### PR DESCRIPTION
To get the seconds value of a period, it first has to be converted to a Duration. Otherwise the wrong value (0) will be used when the Period is not "PTnS" but "PTnH", for example.

Change updateInterval in CollectorRegistrationConfiguration from int to long to avoid a type cast.

Fixes #57