### PR TITLE
Removing usages of deprecated React.createClass().

### DIFF
--- a/src/web/collector-configuration/CollapsibleVerbatim.jsx
+++ b/src/web/collector-configuration/CollapsibleVerbatim.jsx
@@ -3,31 +3,33 @@ import React from 'react';
 import { Alert, Collapse } from 'react-bootstrap';
 import { Input } from 'components/bootstrap';
 
-const CollapsibleVerbatim = React.createClass({
-  propTypes: {
+class CollapsibleVerbatim extends React.Component {
+  static propTypes = {
     type: PropTypes.string,
     value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     let expanded = false;
-    if (this.props.value) {
+    if (props.value) {
       expanded = true;
     }
-    return {
+
+    this.state = {
       expanded: expanded,
     };
-  },
+  }
 
-  _onHandleToggle(e) {
+  _onHandleToggle = (e) => {
     e.preventDefault();
     this.setState({ expanded: !this.state.expanded });
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.props.type;
-  },
+  };
 
   render() {
     const text = this.state.expanded ? 'Hide' : 'Add';
@@ -47,7 +49,7 @@ const CollapsibleVerbatim = React.createClass({
         </Collapse>
       </span>
     );
-  },
-});
+  }
+}
 
 export default CollapsibleVerbatim;

--- a/src/web/collector-configuration/CollectorConfiguration.jsx
+++ b/src/web/collector-configuration/CollectorConfiguration.jsx
@@ -16,18 +16,19 @@ import DeleteConfirmButton from './DeleteConfirmButton';
 import CollectorConfigurationsActions from 'configurations/CollectorConfigurationsActions';
 import TagsSelect from './TagsSelect';
 
-const CollectorConfiguration = React.createClass({
-  propTypes: {
+class CollectorConfiguration extends React.Component {
+  static propTypes = {
     configuration: PropTypes.object.isRequired,
     tags: PropTypes.array.isRequired,
     onConfigurationChange: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     const outputs = {};
     let initialTab = 'beat';
-    outputs.beat = this.props.configuration.outputs.filter(key => key.backend === 'filebeat' || key.backend === 'winlogbeat').length;
-    outputs.nxlog = this.props.configuration.outputs.filter(key => key.backend === 'nxlog').length;
+    outputs.beat = props.configuration.outputs.filter(key => key.backend === 'filebeat' || key.backend === 'winlogbeat').length;
+    outputs.nxlog = props.configuration.outputs.filter(key => key.backend === 'nxlog').length;
 
     if (outputs.beat === 0) {
       const tab = Object.keys(outputs).reduce((a, b) => {
@@ -37,10 +38,10 @@ const CollectorConfiguration = React.createClass({
         initialTab = tab;
       }
     }
-    return { tab: initialTab };
-  },
+    this.state = { tab: initialTab };
+  }
 
-  _headerCellFormatter(header) {
+  _headerCellFormatter = (header) => {
     let className;
 
     switch (header.toLowerCase()) {
@@ -63,9 +64,9 @@ const CollectorConfiguration = React.createClass({
     }
 
     return <th className={className}>{header}</th>;
-  },
+  };
 
-  _outputFormatter(output) {
+  _outputFormatter = (output) => {
     return (
       <tr key={output.output_id}>
         <td>{output.name}</td>
@@ -86,9 +87,9 @@ const CollectorConfiguration = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
 
-  _inputFormatter(input) {
+  _inputFormatter = (input) => {
     var filterOutputs = this.props.configuration.outputs.filter(this._filterConfigurations);
     return (
       <tr key={input.input_id}>
@@ -109,9 +110,9 @@ const CollectorConfiguration = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
 
-  _snippetFormatter(snippet) {
+  _snippetFormatter = (snippet) => {
     return (
       <tr key={snippet.snippet_id}>
         <td>{snippet.name}</td>
@@ -127,91 +128,91 @@ const CollectorConfiguration = React.createClass({
         </td>
       </tr>
     );
-  },
+  };
 
-  _onSuccessfulUpdate(callback) {
+  _onSuccessfulUpdate = (callback) => {
     if (typeof callback === 'function') {
       callback();
     }
     this.props.onConfigurationChange();
-  },
+  };
 
-  _saveOutput(output, callback) {
+  _saveOutput = (output, callback) => {
     CollectorConfigurationsActions.saveOutput.triggerPromise(output, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _saveInput(input, callback) {
+  _saveInput = (input, callback) => {
     CollectorConfigurationsActions.saveInput.triggerPromise(input, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _saveSnippet(snippet, callback) {
+  _saveSnippet = (snippet, callback) => {
     CollectorConfigurationsActions.saveSnippet.triggerPromise(snippet, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _copyOutput(outputId, name, callback) {
+  _copyOutput = (outputId, name, callback) => {
     CollectorConfigurationsActions.copyOutput.triggerPromise(outputId, name, this.props.configuration.id)
         .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _copyInput(inputId, name, callback) {
+  _copyInput = (inputId, name, callback) => {
     CollectorConfigurationsActions.copyInput.triggerPromise(inputId, name, this.props.configuration.id)
         .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _copySnippet(snippetId, name, callback) {
+  _copySnippet = (snippetId, name, callback) => {
     CollectorConfigurationsActions.copySnippet.triggerPromise(snippetId, name, this.props.configuration.id)
         .then(() => this._onSuccessfulUpdate(callback));
-  },
+  };
 
-  _deleteOutput(output) {
+  _deleteOutput = (output) => {
     CollectorConfigurationsActions.deleteOutput.triggerPromise(output, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate());
-  },
+  };
 
-  _deleteInput(input) {
+  _deleteInput = (input) => {
     CollectorConfigurationsActions.deleteInput.triggerPromise(input, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate());
-  },
+  };
 
-  _deleteSnippet(snippet) {
+  _deleteSnippet = (snippet) => {
     CollectorConfigurationsActions.deleteSnippet.triggerPromise(snippet, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate());
-  },
+  };
 
-  _validInputName(name) {
+  _validInputName = (name) => {
     // Check if inputs already contain an input with the given name.
     return !this.props.configuration.inputs.some((input) => input.name === name);
-  },
+  };
 
-  _validOutputName(name) {
+  _validOutputName = (name) => {
     // Check if outputs already contain an output with the given name.
     return !this.props.configuration.outputs.some((output) => output.name === name);
-  },
+  };
 
-  _validSnippetName(name) {
+  _validSnippetName = (name) => {
     // Check if snippets already contain an snippet with the given name.
     return !this.props.configuration.snippets.some((snippet) => snippet.name === name);
-  },
+  };
 
-  _updateTags(event) {
+  _updateTags = (event) => {
     event.preventDefault();
     const tags = this.refs.tags.getValue().filter((value) => value !== '');
     CollectorConfigurationsActions.updateTags(tags, this.props.configuration.id)
       .then(() => this._onSuccessfulUpdate());
-  },
+  };
 
-  _getOutputById(id) {
+  _getOutputById = (id) => {
     return this.props.configuration.outputs.find((output) => output.output_id === id);
-  },
+  };
 
-  _tabSwitched(tabKey) {
+  _tabSwitched = (tabKey) => {
     this.setState({tab: tabKey});
-  },
+  };
 
-  _tabDisplayName() {
+  _tabDisplayName = () => {
     switch(this.state.tab) {
       case 'nxlog':
         return "NXLog";
@@ -222,9 +223,9 @@ const CollectorConfiguration = React.createClass({
       default:
         return "Collector";
     }
-  },
+  };
 
-  _filterConfigurations(element) {
+  _filterConfigurations = (element) => {
     if (this.state.tab == "nxlog" && element.backend == "nxlog") {
       return true;
     }
@@ -232,9 +233,9 @@ const CollectorConfiguration = React.createClass({
       return true;
     }
     return false;
-  },
+  };
 
-  _filteredOutputs() {
+  _filteredOutputs = () => {
     let filebeatOutputs = 0;
     let winlogbeatOutputs = 0;
     const outputs = [
@@ -273,7 +274,7 @@ const CollectorConfiguration = React.createClass({
       }
     });
     return outputs;
-  },
+  };
 
   render() {
     const outputHeaders = ['Output', 'Type', 'Id', 'Actions'];
@@ -402,7 +403,7 @@ const CollectorConfiguration = React.createClass({
         </Row>
       </div>
     );
-  },
-});
+  }
+}
 
 export default CollectorConfiguration;

--- a/src/web/collector-configuration/CollectorConfigurationPage.jsx
+++ b/src/web/collector-configuration/CollectorConfigurationPage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -13,7 +14,9 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
 
-const CollectorConfigurationPage = React.createClass({
+const CollectorConfigurationPage = createReactClass({
+  displayName: 'CollectorConfigurationPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/src/web/collector-configuration/CopyInputModal.jsx
+++ b/src/web/collector-configuration/CopyInputModal.jsx
@@ -4,57 +4,53 @@ import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
-const CopyInputModal = React.createClass({
-    propTypes: {
+class CopyInputModal extends React.Component {
+    static propTypes = {
         id: PropTypes.string,
         copyInput: PropTypes.func.isRequired,
         validInputName: PropTypes.func.isRequired,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            id: '',
-            name: '',
-        };
-    },
+    static defaultProps = {
+        id: '',
+        name: '',
+    };
 
-    getInitialState() {
-        return {
-            id: this.props.id,
-            name: '',
-            error: false,
-            error_message: '',
-        };
-    },
+    state = {
+        id: this.props.id,
+        name: '',
+        error: false,
+        error_message: '',
+    };
 
-    openModal() {
+    openModal = () => {
         this.refs.modal.open();
-    },
+    };
 
-    _getId(prefixIdName) {
+    _getId = (prefixIdName) => {
         return prefixIdName + this.state.name;
-    },
+    };
 
-    _closeModal() {
+    _closeModal = () => {
         this.refs.modal.close();
-    },
+    };
 
-    _saved() {
+    _saved = () => {
         this._closeModal();
         this.setState({ name: '' });
-    },
+    };
 
-    _save() {
+    _save = () => {
         const configuration = this.state;
 
         if (!configuration.error) {
             this.props.copyInput(this.props.id, this.state.name, this._saved);
         }
-    },
+    };
 
-    _changeName(event) {
+    _changeName = (event) => {
         this.setState({ name: event.target.value });
-    },
+    };
 
     render() {
         return (
@@ -82,7 +78,7 @@ const CopyInputModal = React.createClass({
                 </BootstrapModalForm>
             </span>
         );
-    },
-});
+    }
+}
 
 export default CopyInputModal;

--- a/src/web/collector-configuration/CopyOutputModal.jsx
+++ b/src/web/collector-configuration/CopyOutputModal.jsx
@@ -4,57 +4,53 @@ import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
-const CopyOutputModal = React.createClass({
-    propTypes: {
+class CopyOutputModal extends React.Component {
+    static propTypes = {
         id: PropTypes.string,
         copyOutput: PropTypes.func.isRequired,
         validOutputName: PropTypes.func.isRequired,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            id: '',
-            name: '',
-        };
-    },
+    static defaultProps = {
+        id: '',
+        name: '',
+    };
 
-    getInitialState() {
-        return {
-            id: this.props.id,
-            name: '',
-            error: false,
-            error_message: '',
-        };
-    },
+    state = {
+        id: this.props.id,
+        name: '',
+        error: false,
+        error_message: '',
+    };
 
-    openModal() {
+    openModal = () => {
         this.refs.modal.open();
-    },
+    };
 
-    _getId(prefixIdName) {
+    _getId = (prefixIdName) => {
         return prefixIdName + this.state.name;
-    },
+    };
 
-    _closeModal() {
+    _closeModal = () => {
         this.refs.modal.close();
-    },
+    };
 
-    _saved() {
+    _saved = () => {
         this._closeModal();
         this.setState({ name: '' });
-    },
+    };
 
-    _save() {
+    _save = () => {
         const configuration = this.state;
 
         if (!configuration.error) {
             this.props.copyOutput(this.props.id, this.state.name, this._saved);
         }
-    },
+    };
 
-    _changeName(event) {
+    _changeName = (event) => {
         this.setState({ name: event.target.value });
-    },
+    };
 
     render() {
         return (
@@ -82,7 +78,7 @@ const CopyOutputModal = React.createClass({
                 </BootstrapModalForm>
             </span>
         );
-    },
-});
+    }
+}
 
 export default CopyOutputModal;

--- a/src/web/collector-configuration/CopySnippetModal.jsx
+++ b/src/web/collector-configuration/CopySnippetModal.jsx
@@ -4,57 +4,53 @@ import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
-const CopySnippetModal = React.createClass({
-    propTypes: {
+class CopySnippetModal extends React.Component {
+    static propTypes = {
         id: PropTypes.string,
         copySnippet: PropTypes.func.isRequired,
         validSnippetName: PropTypes.func.isRequired,
-    },
+    };
 
-    getDefaultProps() {
-        return {
-            id: '',
-            name: '',
-        };
-    },
+    static defaultProps = {
+        id: '',
+        name: '',
+    };
 
-    getInitialState() {
-        return {
-            id: this.props.id,
-            name: '',
-            error: false,
-            error_message: '',
-        };
-    },
+    state = {
+        id: this.props.id,
+        name: '',
+        error: false,
+        error_message: '',
+    };
 
-    openModal() {
+    openModal = () => {
         this.refs.modal.open();
-    },
+    };
 
-    _getId(prefixIdName) {
+    _getId = (prefixIdName) => {
         return prefixIdName + this.state.name;
-    },
+    };
 
-    _closeModal() {
+    _closeModal = () => {
         this.refs.modal.close();
-    },
+    };
 
-    _saved() {
+    _saved = () => {
         this._closeModal();
         this.setState({ name: '' });
-    },
+    };
 
-    _save() {
+    _save = () => {
         const configuration = this.state;
 
         if (!configuration.error) {
             this.props.copySnippet(this.props.id, this.state.name, this._saved);
         }
-    },
+    };
 
-    _changeName(event) {
+    _changeName = (event) => {
         this.setState({ name: event.target.value });
-    },
+    };
 
     render() {
         return (
@@ -82,7 +78,7 @@ const CopySnippetModal = React.createClass({
                 </BootstrapModalForm>
             </span>
         );
-    },
-});
+    }
+}
 
 export default CopySnippetModal;

--- a/src/web/collector-configuration/DeleteConfirmButton.jsx
+++ b/src/web/collector-configuration/DeleteConfirmButton.jsx
@@ -2,18 +2,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
-const DeleteConfirmButton = React.createClass({
-  propTypes: {
+class DeleteConfirmButton extends React.Component {
+  static propTypes = {
     entity: PropTypes.object.isRequired,
     type: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,
-  },
+  };
 
-  handleClick() {
+  handleClick = () => {
     if (window.confirm(`You are about to delete ${this.props.type} "${this.props.entity.name}". Are you sure?`)) {
       this.props.onClick(this.props.entity);
     }
-  },
+  };
 
   render() {
     return (
@@ -21,7 +21,7 @@ const DeleteConfirmButton = React.createClass({
         Delete
       </Button>
     );
-  },
-});
+  }
+}
 
 export default DeleteConfirmButton;

--- a/src/web/collector-configuration/EditInputFields.jsx
+++ b/src/web/collector-configuration/EditInputFields.jsx
@@ -7,27 +7,23 @@ import { KeyValueTable, Select } from 'components/common';
 
 import CollapsibleVerbatim from './CollapsibleVerbatim';
 
-const EditInputFields = React.createClass({
-  propTypes: {
+class EditInputFields extends React.Component {
+  static propTypes = {
     type: PropTypes.string,
     properties: PropTypes.object,
     errorState: PropTypes.func,
     errorFields: PropTypes.array,
     injectProperties: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      type: '',
-    };
-  },
+  static defaultProps = {
+    type: '',
+  };
 
-  getInitialState() {
-    return {
-      error: false,
-      errorMessage: '',
-    };
-  },
+  state = {
+    error: false,
+    errorMessage: '',
+  };
 
   componentWillMount() {
     this._setDefaultValue(this.props.type, this.props.properties);
@@ -36,13 +32,13 @@ const EditInputFields = React.createClass({
     } else {
       this.setState({fields: {}});
     }
-  },
+  }
 
   componentWillUpdate(nextProps) {
     this._setDefaultValue(nextProps.type, nextProps.properties);
-  },
+  }
 
-  _setDefaultValue(type, value) {
+  _setDefaultValue = (type, value) => {
     switch (type) {
       case 'nxlog:file':
         if (!value.hasOwnProperty('poll_interval')) {
@@ -129,22 +125,22 @@ const EditInputFields = React.createClass({
         };
         break;
     }
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.props.type;
-  },
+  };
 
-  _injectProperty(name) {
+  _injectProperty = (name) => {
     return (event) => this.props.injectProperties(name, FormUtils.getValueFromInput(event.target));
-  },
+  };
 
-  _changeErrorState(error, message, id) {
+  _changeErrorState = (error, message, id) => {
     this.setState({error: error, errorMessage: message});
     this.props.errorState(error, message, id);
-  },
+  };
 
-  _changeFields(fields) {
+  _changeFields = (fields) => {
     for (var key in fields) {
       if (key != this._validField(key)) {
         return
@@ -153,9 +149,9 @@ const EditInputFields = React.createClass({
     };
     this.setState({ fields: fields });
     this.props.injectProperties('fields', fields);
-  },
+  };
 
-  _changeList(name) {
+  _changeList = (name) => {
     return (event) => {
       if (!this._validList(event.target.value)) {
         this._changeErrorState(true, 'Invalid JSON Array. Use the format: [\'first\', \'second\']', event.target.id);
@@ -164,9 +160,9 @@ const EditInputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _changeDuration(name) {
+  _changeDuration = (name) => {
     return (event) => {
       if (!this._validDuration(event.target.value)) {
         this._changeErrorState(true, 'Invalid Duration, it should look like: 10s', event.target.id);
@@ -175,9 +171,9 @@ const EditInputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _changeNumber(name) {
+  _changeNumber = (name) => {
     return (event) => {
       if (!this._validNumber(event.target.value)) {
         this._changeErrorState(true, 'Invalid number', event.target.id);
@@ -186,9 +182,9 @@ const EditInputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _changePattern(name) {
+  _changePattern = (name) => {
     return (event) => {
       if (!this._validPattern(event.target.value)) {
         this._changeErrorState(true, 'Invalid pattern, it should look like: /^foo/', event.target.id);
@@ -197,9 +193,9 @@ const EditInputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _changeXml(name) {
+  _changeXml = (name) => {
     return (event) => {
       if (!this._validXml(event.target.value)) {
         this._changeErrorState(true, 'Invalid XML', event.target.id);
@@ -208,40 +204,40 @@ const EditInputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _validField(value) {
+  _validField = (value) => {
     return value.replace(/[^a-zA-Z0-9-._]/ig, '');
-  },
+  };
 
-  _validList(value) {
+  _validList = (value) => {
     return value.indexOf('\"') === -1 && value.startsWith('[') && value.endsWith(']');
-  },
+  };
 
-  _validDuration(value) {
+  _validDuration = (value) => {
     const durationRex = /(^\d+[smh])|0/;
     return durationRex.test(value);
-  },
+  };
 
-  _validNumber(value) {
+  _validNumber = (value) => {
     return !isNaN(parseInt(value));
-  },
+  };
 
-  _validPattern(value) {
+  _validPattern = (value) => {
     const patternRex = /(^\/.*\/$)|^$/;
     return patternRex.test(value);
-  },
+  };
 
-  _validXml(value) {
+  _validXml = (value) => {
     var parser = new DOMParser();
     var xml = parser.parseFromString(value, "application/xml");
     const parseError = xml.getElementsByTagName("parsererror").length != 0;
     return value.length == 0 || !parseError;
-  },
+  };
 
-  _fieldError(name) {
+  _fieldError = (name) => {
     return this.state.error && this.props.errorFields.indexOf(this._getId(name)) !== -1;
-  },
+  };
 
   render() {
     if (this.props.type) {
@@ -541,7 +537,7 @@ const EditInputFields = React.createClass({
       }
     }
     return (null);
-  },
-});
+  }
+}
 
 export default EditInputFields;

--- a/src/web/collector-configuration/EditInputModal.jsx
+++ b/src/web/collector-configuration/EditInputModal.jsx
@@ -7,8 +7,8 @@ import { BootstrapModalForm, Input } from 'components/bootstrap';
 
 import EditInputFields from './EditInputFields';
 
-const EditInputModal = React.createClass({
-  propTypes: {
+class EditInputModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     backend: PropTypes.string,
@@ -20,59 +20,55 @@ const EditInputModal = React.createClass({
     saveInput: PropTypes.func.isRequired,
     validInputName: PropTypes.func.isRequired,
     selectedGroup: PropTypes.string.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-      properties: {},
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+    properties: {},
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: this.props.name,
-      backend: this.props.backend,
-      type: this.props.type,
-      forwardTo: this.props.forwardTo,
-      properties: this.props.properties,
-      selectedType: (this.props.backend && this.props.type) ? `${this.props.backend}:${this.props.type}` : undefined,
-      error: false,
-      errorMessage: '',
-      errorFields: [],
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: this.props.name,
+    backend: this.props.backend,
+    type: this.props.type,
+    forwardTo: this.props.forwardTo,
+    properties: this.props.properties,
+    selectedType: (this.props.backend && this.props.type) ? `${this.props.backend}:${this.props.type}` : undefined,
+    error: false,
+    errorMessage: '',
+    errorFields: [],
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.state.name;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     if (this.props.create) {
       this.setState({ name: '', backend: '', type: '', selectedType: '', forwardTo: '', properties: {} });
     }
-  },
+  };
 
-  _save() {
+  _save = () => {
     const configuration = this.state;
 
     if (!configuration.error) {
       this.props.saveInput(configuration, this._saved);
     }
-  },
+  };
 
-  _changeErrorState(error, message, id) {
+  _changeErrorState = (error, message, id) => {
     var errorFields = this.state.errorFields.slice();
     const index = errorFields.indexOf(id);
     if (error && index == -1) {
@@ -82,38 +78,38 @@ const EditInputModal = React.createClass({
       errorFields.splice(index, 1);
     }
     this.setState({error: error, errorMessage: message, errorFields: errorFields});
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     this.setState({ name: event.target.value });
-  },
+  };
 
-  _changeForwardtoDropdown(selectedValue) {
+  _changeForwardtoDropdown = (selectedValue) => {
     this.setState({ forwardTo: selectedValue });
-  },
+  };
 
-  _changeProperties(properties) {
+  _changeProperties = (properties) => {
     this.setState({ properties });
-  },
+  };
 
-  _changeType(type) {
+  _changeType = (type) => {
     const backendAndType = type.split(/:/, 2);
     this.setState({ selectedType: type, backend: backendAndType[0], type: backendAndType[1], properties: {} });
-  },
+  };
 
-  _injectProperties(key, value) {
+  _injectProperties = (key, value) => {
     const properties = this.state.properties;
     if (properties) {
       properties[key] = value;
     }
     this.setState({ properties });
-  },
+  };
 
-  _fieldError(name) {
+  _fieldError = (name) => {
     return this.state.error && this.state.errorFields.indexOf(this._getId(name)) !== -1;
-  },
+  };
 
-  _formatDropdownOptions() {
+  _formatDropdownOptions = () => {
     const options = [];
 
     if (this.props.outputs) {
@@ -126,7 +122,7 @@ const EditInputModal = React.createClass({
     }
 
     return options;
-  },
+  };
 
   render() {
     let triggerButtonContent;
@@ -191,7 +187,7 @@ const EditInputModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditInputModal;

--- a/src/web/collector-configuration/EditOutputFields.jsx
+++ b/src/web/collector-configuration/EditOutputFields.jsx
@@ -7,27 +7,23 @@ import { KeyValueTable } from 'components/common';
 
 import CollapsibleVerbatim from './CollapsibleVerbatim';
 
-const EditOutputFields = React.createClass({
-  propTypes: {
+class EditOutputFields extends React.Component {
+  static propTypes = {
     type: PropTypes.string,
     properties: PropTypes.object,
     errorState: PropTypes.func,
     errorFields: PropTypes.array,
     injectProperties: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      type: '',
-    };
-  },
+  static defaultProps = {
+    type: '',
+  };
 
-  getInitialState() {
-    return {
-      error: false,
-      errorMessage: '',
-    };
-  },
+  state = {
+    error: false,
+    errorMessage: '',
+  };
 
   componentWillMount() {
     this._setDefaultValue(this.props.type, this.props.properties);
@@ -36,13 +32,13 @@ const EditOutputFields = React.createClass({
     } else {
       this.setState({fields: {}});
     }
-  },
+  }
 
   componentWillUpdate(nextProps) {
     this._setDefaultValue(nextProps.type, nextProps.properties);
-  },
+  }
 
-  _setDefaultValue(type, value) {
+  _setDefaultValue = (type, value) => {
     switch (type) {
       case 'filebeat:logstash':
         if (!value.hasOwnProperty('hosts')) {
@@ -55,22 +51,22 @@ const EditOutputFields = React.createClass({
         };
         break;
     }
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.props.type;
-  },
+  };
 
-  _injectProperty(name) {
+  _injectProperty = (name) => {
     return (event) => this.props.injectProperties(name, FormUtils.getValueFromInput(event.target));
-  },
+  };
 
-  _changeErrorState(error, message, id) {
+  _changeErrorState = (error, message, id) => {
     this.setState({error: error, errorMessage: message});
     this.props.errorState(error, message, id);
-  },
+  };
 
-  _changeFields(fields) {
+  _changeFields = (fields) => {
     for (var key in fields) {
       if (key != this._validField(key)) {
         return
@@ -79,9 +75,9 @@ const EditOutputFields = React.createClass({
     };
     this.setState({ fields: fields });
     this.props.injectProperties('fields', fields);
-  },
+  };
 
-  _changeList(name) {
+  _changeList = (name) => {
     return (event) => {
       if (!this._validList(event.target.value)) {
         this._changeErrorState(true, 'Invalid JSON Array. Use the format: [\'first\', \'second\']', event.target.id);
@@ -90,19 +86,19 @@ const EditOutputFields = React.createClass({
       }
       this.props.injectProperties(name, FormUtils.getValueFromInput(event.target))
     }
-  },
+  };
 
-  _validField(value) {
+  _validField = (value) => {
     return value.replace(/[^a-zA-Z0-9-._]/ig, '');
-  },
+  };
 
-  _validList(value) {
+  _validList = (value) => {
     return value.indexOf('\"') === -1 && value.startsWith('[') && value.endsWith(']');
-  },
+  };
 
-  _fieldError(name) {
+  _fieldError = (name) => {
     return this.state.error && this.props.errorFields.indexOf(this._getId(name)) !== -1;
-  },
+  };
 
   render() {
     if (this.props) {
@@ -360,7 +356,7 @@ const EditOutputFields = React.createClass({
       }
     }
     return (null);
-  },
-});
+  }
+}
 
 export default EditOutputFields;

--- a/src/web/collector-configuration/EditOutputModal.jsx
+++ b/src/web/collector-configuration/EditOutputModal.jsx
@@ -7,8 +7,8 @@ import { Select } from 'components/common';
 
 import EditOutputFields from './EditOutputFields';
 
-const EditOutputModal = React.createClass({
-  propTypes: {
+class EditOutputModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     backend: PropTypes.string,
@@ -19,58 +19,54 @@ const EditOutputModal = React.createClass({
     validOutputName: PropTypes.func.isRequired,
     selectedGroup: PropTypes.string.isRequired,
     outputList: PropTypes.array.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-      properties: {},
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+    properties: {},
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: this.props.name,
-      backend: this.props.backend,
-      type: this.props.type,
-      properties: this.props.properties,
-      selectedType: (this.props.backend && this.props.type) ? `${this.props.backend}:${this.props.type}` : undefined,
-      error: false,
-      errorMessage: '',
-      errorFields: [],
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: this.props.name,
+    backend: this.props.backend,
+    type: this.props.type,
+    properties: this.props.properties,
+    selectedType: (this.props.backend && this.props.type) ? `${this.props.backend}:${this.props.type}` : undefined,
+    error: false,
+    errorMessage: '',
+    errorFields: [],
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.state.name;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     if (this.props.create) {
       this.setState({ name: '', backend: '', type: '', selectedType: '', properties: {} });
     }
-  },
+  };
 
-  _save() {
+  _save = () => {
     const configuration = this.state;
 
     if (!configuration.error) {
       this.props.saveOutput(configuration, this._saved);
     }
-  },
+  };
 
-  _changeErrorState(error, message, id) {
+  _changeErrorState = (error, message, id) => {
     var errorFields = this.state.errorFields.slice();
     const index = errorFields.indexOf(id);
     if (error && index == -1) {
@@ -80,32 +76,32 @@ const EditOutputModal = React.createClass({
       errorFields.splice(index, 1);
     }
     this.setState({error: error, errorMessage: message, errorFields: errorFields});
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     this.setState({ name: event.target.value });
-  },
+  };
 
-  _changeProperties(properties) {
+  _changeProperties = (properties) => {
     this.setState({ properties });
-  },
+  };
 
-  _changeType(type) {
+  _changeType = (type) => {
     const backendAndType = type.split(/:/, 2);
     this.setState({ selectedType: type, backend: backendAndType[0], type: backendAndType[1], properties: {} });
-  },
+  };
 
-  _injectProperties(key, value) {
+  _injectProperties = (key, value) => {
     const properties = this.state.properties;
     if (properties) {
       properties[key] = value;
     }
     this.setState({ properties });
-  },
+  };
 
-  _fieldError(name) {
+  _fieldError = (name) => {
     return this.state.error && this.state.errorFields.indexOf(this._getId(name)) !== -1;
-  },
+  };
 
   render() {
     let triggerButtonContent;
@@ -151,7 +147,7 @@ const EditOutputModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditOutputModal;

--- a/src/web/collector-configuration/EditSnippetModal.jsx
+++ b/src/web/collector-configuration/EditSnippetModal.jsx
@@ -5,8 +5,8 @@ import { Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { Select } from 'components/common';
 
-const EditSnippetModal = React.createClass({
-  propTypes: {
+class EditSnippetModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     snippet: PropTypes.string,
@@ -15,64 +15,60 @@ const EditSnippetModal = React.createClass({
     saveSnippet: PropTypes.func.isRequired,
     validSnippetName: PropTypes.func.isRequired,
     selectedGroup: PropTypes.string.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: this.props.name,
-      snippet: this.props.snippet,
-      backend: this.props.backend,
-      error: false,
-      error_message: '',
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: this.props.name,
+    snippet: this.props.snippet,
+    backend: this.props.backend,
+    error: false,
+    error_message: '',
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.state.name;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     if (this.props.create) {
       this.setState({ name: '', type: '', snippet: '' });
     }
-  },
+  };
 
-  _save() {
+  _save = () => {
     const configuration = this.state;
 
     if (!configuration.error) {
       this.props.saveSnippet(configuration, this._saved);
     }
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     this.setState({ name: event.target.value });
-  },
+  };
 
-  _changeBackend(selectedBackend) {
+  _changeBackend = (selectedBackend) => {
     this.setState({ backend: selectedBackend });
-  },
+  };
 
-  _changeSnippet(event) {
+  _changeSnippet = (event) => {
     this.setState({ snippet: event.target.value });
-  },
+  };
 
   render() {
     let triggerButtonContent;
@@ -131,7 +127,7 @@ const EditSnippetModal = React.createClass({
         </BootstrapModalForm>
       </span>
     );
-  },
-});
+  }
+}
 
 export default EditSnippetModal;

--- a/src/web/collector-configuration/TagsSelect.jsx
+++ b/src/web/collector-configuration/TagsSelect.jsx
@@ -3,21 +3,19 @@ import React from 'react';
 
 import MultiSelect from 'components/common/MultiSelect';
 
-const TagsSelect = React.createClass({
-  propTypes: {
+class TagsSelect extends React.Component {
+  static propTypes = {
     tags: PropTypes.arrayOf(PropTypes.string),
     availableTags: PropTypes.array.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      tags: [],
-    };
-  },
+  static defaultProps = {
+    tags: [],
+  };
 
-  getValue() {
+  getValue = () => {
     return this.refs.select.getValue().split(',');
-  },
+  };
 
   render() {
     const tagsValue = this.props.tags.join(',');
@@ -33,7 +31,7 @@ const TagsSelect = React.createClass({
         allowCreate
       />
     );
-  },
-});
+  }
+}
 
 export default TagsSelect;

--- a/src/web/collectors/CollectorFilter.jsx
+++ b/src/web/collectors/CollectorFilter.jsx
@@ -5,8 +5,8 @@ import Immutable from 'immutable';
 
 import { TypeAheadInput } from 'components/common';
 
-const CollectorFilter = React.createClass({
-  propTypes: {
+class CollectorFilter extends React.Component {
+  static propTypes = {
     data: PropTypes.array.isRequired,
     searchInKeys: PropTypes.array.isRequired,
     filterBy: PropTypes.string.isRequired,
@@ -16,38 +16,40 @@ const CollectorFilter = React.createClass({
     filterSuggestionAccessor: PropTypes.string,
     filterSuggestions: PropTypes.array,
     label: PropTypes.string,
-  },
-  getDefaultProps() {
-    return {
-      label: 'Filter',
-      displayKey: 'value',
-      filterData: undefined,
-      filterSuggestionAccessor: undefined,
-      filterSuggestions: [],
-    };
-  },
-  getInitialState() {
-    return {
-      filterText: '',
-      filters: Immutable.OrderedSet(),
-    };
-  },
-  _onSearchTextChanged(event) {
+  };
+
+  static defaultProps = {
+    label: 'Filter',
+    displayKey: 'value',
+    filterData: undefined,
+    filterSuggestionAccessor: undefined,
+    filterSuggestions: [],
+  };
+
+  state = {
+    filterText: '',
+    filters: Immutable.OrderedSet(),
+  };
+
+  _onSearchTextChanged = (event) => {
     event.preventDefault();
     this.setState({ filterText: this._typeAheadInput.getValue() }, this.filterData);
-  },
-  _onFilterAdded(event, suggestion) {
+  };
+
+  _onFilterAdded = (event, suggestion) => {
     this.setState({
       filters: this.state.filters.add(suggestion[this.props.displayKey]),
       filterText: '',
     }, this.filterData);
     this._typeAheadInput.clear();
-  },
-  _onFilterRemoved(event) {
+  };
+
+  _onFilterRemoved = (event) => {
     event.preventDefault();
     this.setState({ filters: this.state.filters.delete(event.target.getAttribute('data-target')) }, this.filterData);
-  },
-  _matchFilters(datum) {
+  };
+
+  _matchFilters = (datum) => {
     return this.state.filters.every((filter) => {
       let dataToFilter = datum[this.props.filterBy];
 
@@ -62,8 +64,9 @@ const CollectorFilter = React.createClass({
 
       return dataToFilter.indexOf(filter.toLocaleLowerCase()) !== -1;
     }, this);
-  },
-  _matchStringSearch(datum) {
+  };
+
+  _matchStringSearch = (datum) => {
     return this.props.searchInKeys.some((searchInKey) => {
       const key = datum[searchInKey];
       const value = this.state.filterText;
@@ -83,12 +86,14 @@ const CollectorFilter = React.createClass({
       }
       return containsFilter(key, value);
     }, this);
-  },
-  _resetFilters() {
+  };
+
+  _resetFilters = () => {
     this._typeAheadInput.clear();
     this.setState({ filterText: '', filters: Immutable.OrderedSet() }, this.filterData);
-  },
-  _getStatusText(state) {
+  };
+
+  _getStatusText = (state) => {
     switch (state) {
       case 0:
         return 'Running';
@@ -99,8 +104,9 @@ const CollectorFilter = React.createClass({
       default:
         return 'Unknown';
     }
-  },
-  _transform(collectors) {
+  };
+
+  _transform = (collectors) => {
     return collectors.map((collector) => {
       const transformedCollector = {
         id: collector.id,
@@ -118,8 +124,9 @@ const CollectorFilter = React.createClass({
       }
       return transformedCollector;
     });
-  },
-  filterData() {
+  };
+
+  filterData = () => {
     if (typeof this.props.filterData === 'function') {
       return this.props.filterData(this.props.data);
     }
@@ -136,7 +143,8 @@ const CollectorFilter = React.createClass({
     });
 
     this.props.onDataFiltered(mappedData);
-  },
+  };
+
   render() {
     const filters = this.state.filters.map((filter) => {
       return (
@@ -193,7 +201,7 @@ const CollectorFilter = React.createClass({
         </ul>
       </div>
     );
-  },
-});
+  }
+}
 
 export default CollectorFilter;

--- a/src/web/collectors/CollectorRow.jsx
+++ b/src/web/collectors/CollectorRow.jsx
@@ -1,15 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Label } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import Routes from 'routing/Routes';
 import { Timestamp } from 'components/common';
 
-const CollectorRow = React.createClass({
+const CollectorRow = createReactClass({
+  displayName: 'CollectorRow',
+
   propTypes: {
     collector: PropTypes.object.isRequired,
   },
+
   getInitialState() {
     return {
       showRelativeTime: true,

--- a/src/web/collectors/CollectorsList.jsx
+++ b/src/web/collectors/CollectorsList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col, Alert, Button } from 'react-bootstrap';
 import naturalSort from 'javascript-natural-sort';
@@ -10,7 +11,8 @@ import CollectorsActions from './CollectorsActions';
 import CollectorRow from './CollectorRow';
 import CollectorFilter from './CollectorFilter';
 
-const CollectorList = React.createClass({
+const CollectorList = createReactClass({
+  displayName: 'CollectorList',
   mixins: [Reflux.connect(CollectorsStore)],
 
   getInitialState() {
@@ -23,11 +25,13 @@ const CollectorList = React.createClass({
       showInactive: false,
     };
   },
+
   componentDidMount() {
     this.style.use();
     this._reloadCollectors();
     this.interval = setInterval(this._reloadCollectors, this.COLLECTOR_DATA_REFRESH);
   },
+
   componentWillUnmount() {
     this.style.unuse();
     if (this.interval) {
@@ -41,18 +45,22 @@ const CollectorList = React.createClass({
   _reloadCollectors() {
     CollectorsActions.list.triggerPromise().then(this._setCollectors);
   },
+
   _setCollectors(collectors) {
     this.setState({collectors: collectors.collectors});
   },
+
   _bySortField(collector1, collector2) {
     const sort = this.state.sort;
     const field1 = sort(collector1);
     const field2 = sort(collector2);
     return (this.state.sortDesc ? naturalSort(field2, field1) : naturalSort(field1, field2));
   },
+
   _getTableHeaderClassName(field) {
     return (this.state.sortBy === field ? (this.state.sortDesc ? 'sort-desc' : 'sort-asc') : 'sortable');
   },
+
   _formatCollectorList(collectors) {
     return (
       <div className="table-responsive">
@@ -83,9 +91,11 @@ const CollectorList = React.createClass({
       </div>
     );
   },
+
   toggleShowInactive() {
     this.setState({ showInactive: !this.state.showInactive });
   },
+
   sortById() {
     this.setState({
       sortBy: 'id',
@@ -95,6 +105,7 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   sortByNodeId() {
     this.setState({
       sortBy: 'node_id',
@@ -104,6 +115,7 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   sortByOperatingSystem() {
     this.setState({
       sortBy: 'operating_system',
@@ -113,6 +125,7 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   sortByLastSeen() {
     this.setState({
       sortBy: 'last_seen',
@@ -122,6 +135,7 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   sortByCollectorVersion() {
     this.setState({
       sortBy: 'collector_version',
@@ -131,6 +145,7 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   sortByCollectorStatus() {
     this.setState({
       sortBy: 'collector_status',
@@ -144,13 +159,16 @@ const CollectorList = React.createClass({
       },
     });
   },
+
   _formatEmptyListAlert() {
     const showInactiveHint = (this.state.showInactive ? null : ' and/or click on "Include inactive collectors"');
     return <Alert>There are no collectors to show. Try adjusting your search filter{showInactiveHint}.</Alert>;
   },
+
   _onFilterChange(filteredRows) {
     this.setState({ filteredRows });
   },
+
   _isLoading() {
     return !this.state.collectors;
   },

--- a/src/web/collectors/CollectorsPage.jsx
+++ b/src/web/collectors/CollectorsPage.jsx
@@ -11,7 +11,7 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
 
-const CollectorsPage = React.createClass({
+class CollectorsPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Collectors">
@@ -45,7 +45,7 @@ const CollectorsPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default CollectorsPage;

--- a/src/web/collectors/CollectorsRestartButton.jsx
+++ b/src/web/collectors/CollectorsRestartButton.jsx
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 
 import CollectorsActions from 'collectors/CollectorsActions';
 
-const CollectorsRestartButton = React.createClass({
+const CollectorsRestartButton = createReactClass({
+  displayName: 'CollectorsRestartButton',
+
   propTypes: {
     collector: PropTypes.object.isRequired,
     backend: PropTypes.string.isRequired,

--- a/src/web/collectors/CollectorsStatusFileList.jsx
+++ b/src/web/collectors/CollectorsStatusFileList.jsx
@@ -3,16 +3,16 @@ import React from 'react';
 
 import { DataTable, Spinner, Timestamp } from 'components/common';
 
-const CollectorsStatusFileList = React.createClass({
-  propTypes: {
+class CollectorsStatusFileList extends React.Component {
+  static propTypes = {
     files: PropTypes.array.isRequired,
-  },
+  };
 
-  _headerCellFormatter(header) {
+  _headerCellFormatter = (header) => {
     return <th>{header}</th>;
-  },
+  };
 
-  _activityFormatter(time) {
+  _activityFormatter = (time) => {
     var now = new Date().getTime();
     var modDate = new Date(time).getTime();
     if (modDate > (now - 60000)) {
@@ -20,17 +20,17 @@ const CollectorsStatusFileList = React.createClass({
     } else {
       return("");
     }
-  },
+  };
 
-  _dirFormatter(file) {
+  _dirFormatter = (file) => {
     if(file.is_dir) {
       return(<span><i className="fa fa-folder-open"/>&nbsp;&nbsp;{file.path}</span>);
     } else {
       return(<span><i className="fa fa-file-o"/>&nbsp;&nbsp;{file.path}</span>);
     }
-  },
+  };
 
-  _fileListFormatter(file) {
+  _fileListFormatter = (file) => {
     const format = "YYYY-MM-DD HH:mm:ss";
 
     return (
@@ -40,7 +40,7 @@ const CollectorsStatusFileList = React.createClass({
         <td>{this._dirFormatter(file)}</td>
       </tr>
     );
-  },
+  };
 
   render() {
     var filterKeys = [];
@@ -60,6 +60,6 @@ const CollectorsStatusFileList = React.createClass({
       </div>
     );
   }
-});
+}
 
 export default CollectorsStatusFileList;

--- a/src/web/collectors/CollectorsStatusPage.jsx
+++ b/src/web/collectors/CollectorsStatusPage.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import createReactClass from 'create-react-class';
+
 import { Alert, Row, Col, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -15,7 +17,9 @@ import CollectorsRestartButton from 'collectors/CollectorsRestartButton';
 
 import Routes from 'routing/Routes';
 
-const CollectorsStatusPage = React.createClass({
+const CollectorsStatusPage = createReactClass({
+  displayName: 'CollectorsStatusPage',
+
   propTypes: {
     params: PropTypes.object.isRequired,
   },

--- a/src/web/configurations/ConfigurationRow.jsx
+++ b/src/web/configurations/ConfigurationRow.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Label } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
@@ -8,7 +9,9 @@ import CopyConfigurationModal from './CopyConfigurationModal';
 
 import Routes from 'routing/Routes';
 
-const ConfigurationRow = React.createClass({
+const ConfigurationRow = createReactClass({
+  displayName: 'ConfigurationRow',
+
   propTypes: {
     configuration: PropTypes.object.isRequired,
     onUpdate: PropTypes.func.isRequired,

--- a/src/web/configurations/ConfigurationsList.jsx
+++ b/src/web/configurations/ConfigurationsList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DataTable, Spinner } from 'components/common';
@@ -8,7 +9,8 @@ import ConfigurationRow from './ConfigurationRow';
 import CollectorConfigurationsActions from './CollectorConfigurationsActions';
 import EditConfigurationModal from './EditConfigurationModal';
 
-const ConfigurationsList = React.createClass({
+const ConfigurationsList = createReactClass({
+  displayName: 'ConfigurationsList',
   mixins: [Reflux.connect(CollectorConfigurationsStore)],
 
   componentDidMount() {

--- a/src/web/configurations/ConfigurationsPage.jsx
+++ b/src/web/configurations/ConfigurationsPage.jsx
@@ -11,7 +11,7 @@ import ConfigurationsList from './ConfigurationsList';
 
 import Routes from 'routing/Routes';
 
-const ConfigurationsPage = React.createClass({
+class ConfigurationsPage extends React.Component {
   render() {
     return (
       <DocumentTitle title="Collector sidecar configurations">
@@ -46,7 +46,7 @@ const ConfigurationsPage = React.createClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export default ConfigurationsPage;

--- a/src/web/configurations/CopyConfigurationModal.jsx
+++ b/src/web/configurations/CopyConfigurationModal.jsx
@@ -4,57 +4,53 @@ import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
-const CopyConfigurationModal = React.createClass({
-  propTypes: {
+class CopyConfigurationModal extends React.Component {
+  static propTypes = {
     id: PropTypes.string,
     copyConfiguration: PropTypes.func.isRequired,
     validConfigurationName: PropTypes.func.isRequired,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      id: '',
-      name: '',
-    };
-  },
+  static defaultProps = {
+    id: '',
+    name: '',
+  };
 
-  getInitialState() {
-    return {
-      id: this.props.id,
-      name: '',
-      error: false,
-      error_message: '',
-    };
-  },
+  state = {
+    id: this.props.id,
+    name: '',
+    error: false,
+    error_message: '',
+  };
 
-  openModal() {
+  openModal = () => {
     this.refs.modal.open();
-  },
+  };
 
-  _getId(prefixIdName) {
+  _getId = (prefixIdName) => {
     return prefixIdName + this.state.name;
-  },
+  };
 
-  _closeModal() {
+  _closeModal = () => {
     this.refs.modal.close();
-  },
+  };
 
-  _saved() {
+  _saved = () => {
     this._closeModal();
     this.setState({ name: '' });
-  },
+  };
 
-  _save() {
+  _save = () => {
     const configuration = this.state;
 
     if (!configuration.error) {
       this.props.copyConfiguration(this.props.id, this.state.name, this._saved);
     }
-  },
+  };
 
-  _changeName(event) {
+  _changeName = (event) => {
     this.setState({ name: event.target.value });
-  },
+  };
 
   render() {
     return (
@@ -82,7 +78,7 @@ const CopyConfigurationModal = React.createClass({
                 </BootstrapModalForm>
             </span>
     );
-  },
-});
+  }
+}
 
 export default CopyConfigurationModal;

--- a/src/web/configurations/EditConfigurationModal.jsx
+++ b/src/web/configurations/EditConfigurationModal.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import ObjectUtils from 'util/ObjectUtils';
 
-const EditConfigurationModal = React.createClass({
+const EditConfigurationModal = createReactClass({
+  displayName: 'EditConfigurationModal',
+
   propTypes: {
     configuration: PropTypes.object,
     create: PropTypes.bool,

--- a/src/web/system-configuration/CollectorSystemConfiguration.jsx
+++ b/src/web/system-configuration/CollectorSystemConfiguration.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button } from 'react-bootstrap';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, ISODurationInput } from 'components/common';
@@ -8,7 +9,9 @@ import ISODurationUtils from 'util/ISODurationUtils';
 import FormUtils from 'util/FormsUtils';
 import StringUtils from 'util/StringUtils';
 
-const CollectorSystemConfiguration = React.createClass({
+const CollectorSystemConfiguration = createReactClass({
+  displayName: 'CollectorSystemConfiguration',
+
   propTypes: {
     config: PropTypes.shape({
       collector_expiration_threshold: PropTypes.string,


### PR DESCRIPTION
This PR was generated using the class.js react codemod[1]. It converts all
suitable react components to ES6 classes. If an ES5 component which uses
`React.createClass()` is not suitable for conversion, it uses the
`createReactClass()` helper supplied by the `create-react-class` module.

This change is necessary in preparation for React 16, which removes
`React.createClass()` completely[2]. The codemod used claims to be very
reliable even in corner cases and supposedly `has converted thousands of
components internally at Facebook.`.

[1]: https://github.com/reactjs/react-codemod#explanation-of-the-new-es2015-class-transform-with-property-initializers
[2]: https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactcreateclass

It was run like this:

```
$ jscodeshift --extensions js,jsx -t ~/graylog2/react-codemod/transforms/class.js src
Processing 31 files...
Spawning 7 workers...
Sending 5 files to free worker...
Sending 5 files to free worker...
Sending 5 files to free worker...
Sending 5 files to free worker...
Sending 5 files to free worker...
Sending 5 files to free worker...
Sending 1 files to free worker...
src/web/configurations/EditConfigurationModal.jsx: `EditConfigurationModal` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/web/collectors/CollectorsRestartButton.jsx: `CollectorsRestartButton` was skipped because of invalid field(s) `BUTTON_REFRESH` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/web/collectors/CollectorsList.jsx: `CollectorList` was skipped because of inconvertible mixins.
src/web/configurations/ConfigurationRow.jsx: `ConfigurationRow` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/web/collectors/CollectorsStatusPage.jsx: `CollectorsStatusPage` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/web/system-configuration/CollectorSystemConfiguration.jsx: `CollectorSystemConfiguration` was skipped because of API calls that will be removed. Remove calls to `getDefaultProps` and/or `getInitialState` in your React component and re-run this script.
src/web/collectors/CollectorRow.jsx: `CollectorRow` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
src/web/configurations/ConfigurationsList.jsx: `ConfigurationsList` was skipped because of inconvertible mixins.
src/web/collector-configuration/CollectorConfigurationPage.jsx: `CollectorConfigurationPage` was skipped because of invalid field(s) `style` on the React component. Remove any right-hand-side expressions that are not simple, like: `componentWillUpdate: createWillUpdate()` or `render: foo ? renderA : renderB`.
All done.
Results:
0 errors
5 unmodified
0 skipped
26 ok
Time elapsed: 3.021seconds
```