### PR TITLE
Add deprecation warning to collector pages

### DIFF
--- a/src/web/collector-configuration/CollectorConfigurationPage.jsx
+++ b/src/web/collector-configuration/CollectorConfigurationPage.jsx
@@ -64,10 +64,16 @@ const CollectorConfigurationPage = createReactClass({
       return <Spinner />;
     }
 
+    const lifecycleMessage = (
+      <span>The Graylog Collector plugin is discontinued and has been superseded by the new Sidecars.</span>
+    );
+
     return (
       <DocumentTitle title={`Collector ${this.state.configuration.name} configuration`}>
         <div>
-          <PageHeader title={<span>Collector <em>{this.state.configuration.name}</em> Configuration</span>}>
+          <PageHeader title={<span>Collector <em>{this.state.configuration.name}</em> Configuration</span>}
+                      lifecycle="legacy"
+                      lifecycleMessage={lifecycleMessage}>
             <span>
               Use this page to review and manage the configuration for this collector.
             </span>

--- a/src/web/collectors/CollectorsPage.jsx
+++ b/src/web/collectors/CollectorsPage.jsx
@@ -1,22 +1,27 @@
 import React from 'react';
-
 import { Row, Col, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import DocsHelper from 'util/DocsHelper';
 
 import { DocumentTitle, PageHeader } from 'components/common';
-import CollectorList from './CollectorsList';
 import DocumentationLink from 'components/support/DocumentationLink';
-
 import Routes from 'routing/Routes';
+
+import CollectorList from './CollectorsList';
 
 class CollectorsPage extends React.Component {
   render() {
+    const lifecycleMessage = (
+      <span>The Graylog Collector plugin is discontinued and has been superseded by the new Sidecars.</span>
+    );
+
     return (
       <DocumentTitle title="Collectors">
         <span>
-          <PageHeader title="Collectors in Cluster">
+          <PageHeader title="Collectors in Cluster"
+                      lifecycle="legacy"
+                      lifecycleMessage={lifecycleMessage}>
             <span>
               The Graylog collectors can reliably forward contents of log files or Windows EventLog from your servers.
             </span>

--- a/src/web/collectors/CollectorsStatusPage.jsx
+++ b/src/web/collectors/CollectorsStatusPage.jsx
@@ -148,10 +148,16 @@ const CollectorsStatusPage = createReactClass({
     });
     const logFileList = this.state.collector.node_details.log_file_list || [];
 
+    const lifecycleMessage = (
+      <span>The Graylog Collector plugin is discontinued and has been superseded by the new Sidecars.</span>
+    );
+
     return (
       <DocumentTitle title={`Collector status ${this.state.collector.node_id}`}>
         <span>
-          <PageHeader title={<span>Collector Status <em>{this.state.collector.node_id}</em></span>}>
+          <PageHeader title={<span>Collector Status <em>{this.state.collector.node_id}</em></span>}
+                      lifecycle="legacy"
+                      lifecycleMessage={lifecycleMessage}>
             <span>
               A status overview of all running collector backends on this host.
             </span>

--- a/src/web/configurations/ConfigurationsPage.jsx
+++ b/src/web/configurations/ConfigurationsPage.jsx
@@ -13,10 +13,16 @@ import Routes from 'routing/Routes';
 
 class ConfigurationsPage extends React.Component {
   render() {
+    const lifecycleMessage = (
+      <span>The Graylog Collector plugin is discontinued and has been superseded by the new Sidecars.</span>
+    );
+
     return (
       <DocumentTitle title="Collector sidecar configurations">
         <span>
-          <PageHeader title="Collector Sidecar Configurations">
+          <PageHeader title="Collector Sidecar Configurations"
+                      lifecycle="legacy"
+                      lifecycleMessage={lifecycleMessage}>
             <span>
               The Collector Sidecar runs next to your favourite log collector and configures it for you. Here you can
               manage the Sidecar configurations.

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -21,7 +21,7 @@ const manifest = new PluginManifest(packageJson, {
   // Adding an element to the top navigation pointing to /sample named "Sample":
 
   systemnavigation: [
-    { path: '/system/collectors', description: 'Collectors (deprecated)', permissions: 'collectors:read' },
+    { path: '/system/collectors', description: 'Collectors (legacy)', permissions: 'collectors:read' },
   ],
 
   systemConfigurations: [


### PR DESCRIPTION
Requires https://github.com/Graylog2/graylog2-server/pull/5133 to work.

Fixes #90.
