### PR TITLE
Rename the system configuration for old Collectors

### DIFF
--- a/src/web/system-configuration/CollectorSystemConfiguration.jsx
+++ b/src/web/system-configuration/CollectorSystemConfiguration.jsx
@@ -97,7 +97,7 @@ const CollectorSystemConfiguration = createReactClass({
   render() {
     return (
       <div>
-        <h3>Collectors System</h3>
+        <h3>Collectors (legacy) System</h3>
 
         <dl className="deflist">
           <dt>Inactive threshold:</dt>


### PR DESCRIPTION
The UI now has two global sidecar settings.
Make it more obvious if you're tweaking the old one.