### PR TITLE
Rename the system configuration for old Collectors (#97)

### DIFF
--- a/src/web/system-configuration/CollectorSystemConfiguration.jsx
+++ b/src/web/system-configuration/CollectorSystemConfiguration.jsx
@@ -97,7 +97,7 @@ const CollectorSystemConfiguration = createReactClass({
   render() {
     return (
       <div>
-        <h3>Collectors System</h3>
+        <h3>Collectors (legacy) System</h3>
 
         <dl className="deflist">
           <dt>Inactive threshold:</dt>


### PR DESCRIPTION
The UI now has two global sidecar settings.
Make it more obvious if you're tweaking the old one.

(cherry picked from commit f17288086c89e7a2f1b6440c08a60d6f14440089)