### PR TITLE
use only moment-timezone

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,11 +2791,10 @@ graceful-fs@^4.1.2:
   dependencies:
     "@babel/preset-env" "7.8.4"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:../../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-3.3.0-SNAPSHOT-97c85d7c-a19a-4b01-b2f9-1d3d3b0e71f5-1582722055516/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-3.3.0-SNAPSHOT-312302df-1386-4018-9fa9-fbf1ea5344c6-1583331721689/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"
-    moment "2.24.0"
     moment-timezone "0.5.28"
     prop-types "15.7.2"
     react "16.12.0"
@@ -3716,15 +3715,10 @@ moment-timezone@0.5.28:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.24.0:
+"moment@>= 2.9.0":
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-"moment@>= 2.9.0":
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
-  integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Remove `moment.js` and only use `moment-timezone` which loads in the latest `moment.js` as a dependency.