### PR TITLE
Reusing link component abstraction from core.

### DIFF
--- a/src/web/collector-configuration/CollectorConfigurationPage.jsx
+++ b/src/web/collector-configuration/CollectorConfigurationPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/src/web/collectors/CollectorRow.jsx
+++ b/src/web/collectors/CollectorRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, Label } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/src/web/collectors/CollectorsPage.jsx
+++ b/src/web/collectors/CollectorsPage.jsx
@@ -1,9 +1,7 @@
-import React from 'react';
-import { Link } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
-
 import DocsHelper from 'util/DocsHelper';
 
+import React from 'react';
+import { Link, LinkContainer } from 'components/graylog/router';
 import { Button, Col, Modal, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -11,7 +9,6 @@ import { BootstrapModalWrapper } from 'components/bootstrap';
 import Routes from 'routing/Routes';
 
 import CollectorList from './CollectorsList';
-
 import style from './CollectorsPage.css';
 
 class CollectorsPage extends React.Component {

--- a/src/web/collectors/CollectorsStatusPage.jsx
+++ b/src/web/collectors/CollectorsStatusPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import Semver from 'semver';
 
 import { Alert, Row, Col, Button } from 'components/graylog';

--- a/src/web/collectors/ImportsHelperModal.jsx
+++ b/src/web/collectors/ImportsHelperModal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
-
+import { Link } from 'components/graylog/router';
 import { Alert, Button, Modal } from 'components/graylog';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import Routes from 'routing/Routes';

--- a/src/web/configurations/ConfigurationRow.jsx
+++ b/src/web/configurations/ConfigurationRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/src/web/configurations/ConfigurationsPage.jsx
+++ b/src/web/configurations/ConfigurationsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';


### PR DESCRIPTION
This PR is reusing the link component abstraction from core, implemented in Graylog2/graylog2-server#9030.

/jenkins-pr-deps Graylog2/graylog2-server#9030