### PR TITLE
Remove `--bail` flag from webpack build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "Graylog2/graylog-plugin-collector"
   },
   "scripts": {
-    "build": "webpack --bail"
+    "build": "webpack"
   },
   "keywords": [
     "graylog"


### PR DESCRIPTION
Due to a recent `webpack-cli` upgrade, we need to remove the `--bail` flag from the build command, as it is not supported anymore and breaks the build.