### PR TITLE
Improve button naming and remove not needed usage of CSS line-height.

### DIFF
--- a/src/web/collectors/CollectorsPage.css
+++ b/src/web/collectors/CollectorsPage.css
@@ -9,11 +9,9 @@
 :local(.sidecarModal) h4 {
     font-size: 16px;
     font-weight: 500;
-    line-height: 1.1;
     margin-bottom: 5px;
 }
 
 :local(.sidecarModal) p {
-    line-height: 1.3;
     margin-bottom: 15px;
 }

--- a/src/web/configurations/EditConfigurationModal.jsx
+++ b/src/web/configurations/EditConfigurationModal.jsx
@@ -98,7 +98,7 @@ const EditConfigurationModal = createReactClass({
         <BootstrapModalForm ref="modal"
                             title={`${this.props.create ? 'Create' : 'Edit'} Configuration ${this.state.configuration.name}`}
                             onSubmitForm={this._save}
-                            submitButtonText="Save">
+                            submitButtonText={`${this.props.create ? 'Create' : 'Update'} configuration`}>
           <fieldset>
             <Input type="text"
                    id={this._getId('configuration-name')}

--- a/src/web/system-configuration/CollectorSystemConfiguration.jsx
+++ b/src/web/system-configuration/CollectorSystemConfiguration.jsx
@@ -131,14 +131,16 @@ const CollectorSystemConfiguration = createReactClass({
         </dl>
 
         <IfPermitted permissions="clusterconfigentry:edit">
-          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>
+            Edit configuration
+          </Button>
         </IfPermitted>
 
         <BootstrapModalForm ref="configModal"
                             title="Update Collectors System Configuration"
                             onSubmitForm={this._saveConfig}
                             onModalClose={this._resetConfig}
-                            submitButtonText="Save">
+                            submitButtonText="Update configuration">
           <fieldset>
             <ISODurationInput id="inactive-threshold-field"
                               duration={this.state.config.collector_inactive_threshold}


### PR DESCRIPTION
## Description

Mini PR to improve button naming and line-heights.

Related to https://github.com/Graylog2/graylog2-server/pull/13513 and https://github.com/Graylog2/graylog2-server/pull/13530


